### PR TITLE
Added support to lock/unlock using s3 bucket only

### DIFF
--- a/internal/backend/remote-state/s3/backend.go
+++ b/internal/backend/remote-state/s3/backend.go
@@ -28,6 +28,13 @@ import (
 	"golang.org/x/exp/maps"
 )
 
+type LockStorageType string
+
+var (
+	DynamoDB = LockStorageType("DynamoDB")
+	S3Bucket = LockStorageType("S3Bucket")
+)
+
 func New() backend.Backend {
 	return &Backend{}
 }
@@ -36,6 +43,8 @@ type Backend struct {
 	awsConfig aws.Config
 	s3Client  *s3.Client
 	dynClient *dynamodb.Client
+
+	lockStorageType LockStorageType
 
 	bucketName            string
 	keyName               string
@@ -315,6 +324,11 @@ func (b *Backend) ConfigSchema() *configschema.Block {
 				Type:        cty.Bool,
 				Optional:    true,
 				Description: "Force the backend to resolve endpoints with DualStack capability.",
+			},
+			"lock_storage_type": {
+				Type:        cty.String,
+				Optional:    true,
+				Description: "Type of lock storage(S3Bucket or DynamoDB)",
 			},
 		},
 	}
@@ -819,6 +833,16 @@ func (b *Backend) PrepareConfig(obj cty.Value) (cty.Value, tfdiags.Diagnostics) 
 		endpointModeValidators.ValidateAttr(val, attrPath, &diags)
 	}
 
+	attrPath = cty.GetAttrPath("lock_storage_type")
+	if val := obj.GetAttr("lock_storage_type"); !val.IsNull() {
+		lockStorageValidator := validateString{
+			Validators: []stringValidator{
+				validateStringInSlice([]string{string(DynamoDB), string(S3Bucket)}),
+			},
+		}
+		lockStorageValidator.ValidateAttr(val, attrPath, &diags)
+	}
+
 	validateAttributesConflict(
 		cty.GetAttrPath("allowed_account_ids"),
 		cty.GetAttrPath("forbidden_account_ids"),
@@ -903,7 +927,7 @@ func (b *Backend) Configure(obj cty.Value) tfdiags.Diagnostics {
 	b.serverSideEncryption = boolAttr(obj, "encrypt")
 	b.kmsKeyID = stringAttr(obj, "kms_key_id")
 	b.ddbTable = stringAttr(obj, "dynamodb_table")
-
+	b.lockStorageType = LockStorageType(stringAttr(obj, "lock_storage_type"))
 	if _, ok := stringAttrOk(obj, "kms_key_id"); ok {
 		if customerKey := os.Getenv("AWS_SSE_CUSTOMER_KEY"); customerKey != "" {
 			diags = diags.Append(wholeBodyErrDiag(

--- a/internal/backend/remote-state/s3/backend_state.go
+++ b/internal/backend/remote-state/s3/backend_state.go
@@ -151,6 +151,9 @@ func (b *Backend) remoteClient(name string) (*RemoteClient, error) {
 		acl:                   b.acl,
 		kmsKeyID:              b.kmsKeyID,
 		ddbTable:              b.ddbTable,
+		lockStorageType:       b.lockStorageType,
+		lockFileName:          b.lockFileName(),
+		digestFileName:        b.digestFileName(),
 	}
 
 	return client, nil
@@ -238,6 +241,13 @@ func (b *Backend) path(name string) string {
 	}
 
 	return path.Join(b.workspaceKeyPrefix, name, b.keyName)
+}
+
+func (b *Backend) lockFileName() string {
+	return fmt.Sprintf("%s.lock", b.keyName)
+}
+func (b *Backend) digestFileName() string {
+	return fmt.Sprintf("%s.digest", b.keyName)
 }
 
 const errStateUnlock = `


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.5.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  
